### PR TITLE
Fix(patch) : Path Traversal via Moby builder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,29 +6,32 @@ require (
 	github.com/ExpediaGroup/flyte-client v1.4.0
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/adhocore/gronx v0.2.4
+	github.com/containerd/log v0.1.0 // indirect
 	github.com/coreos/go-oidc v2.1.0+incompatible
-	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v1.13.1
+	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/docker v25.0.6+incompatible
 	github.com/docker/go-connections v0.3.0
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-yaml/yaml v2.1.0+incompatible
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.1+incompatible
-	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/husobee/vestigo v1.1.0
 	github.com/jasonlvhit/gocron v0.0.0-20190920201010-985d45da66c5
 	github.com/juju/errors v0.0.0-20190806202954-0232dcc7464d // indirect
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/moby/term v0.5.0 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/rs/zerolog v1.26.1
-	github.com/stretchr/testify v1.7.1
+	github.com/stretchr/testify v1.9.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v1.1.0
-	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
-	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
-	google.golang.org/appengine v1.6.2 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.31.0 // indirect
+	golang.org/x/net v0.30.0
+	golang.org/x/time v0.7.0 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
 	gopkg.in/square/go-jose.v2 v2.3.1
 )


### PR DESCRIPTION
### :pencil: Description
util/binfmt_misc/check.go in Builder in Docker Engine before 19.03.9 calls os.OpenFile with a potentially unsafe qemu-check temporary pathname, constructed with an empty first argument in an ioutil.TempDir call.

[CWE-22](https://cwe.mitre.org/data/definitions/22.html)
[CVE-2020-27534](https://nvd.nist.gov/vuln/detail/CVE-2020-27534)
